### PR TITLE
add nonce to send action to counteract duplicate trx error

### DIFF
--- a/distribution/distribution.cpp
+++ b/distribution/distribution.cpp
@@ -138,7 +138,8 @@ void distribution::empty(name distri_id, uint8_t batch_size){
 
 }
 
-void distribution::send(name distri_id, uint8_t batch_size){
+void distribution::send(name distri_id, uint8_t batch_size, uint64_t nonce){
+    //the nonce is for counteracting the "duplicate transaction" error when calling the action in a loop. uint64 is choosen for flexibility.
 
     districonf_table districonf_t(get_self(), get_self().value);
     auto existing_distri = districonf_t.find(distri_id.value);

--- a/distribution/distribution.hpp
+++ b/distribution/distribution.hpp
@@ -29,7 +29,7 @@ CONTRACT distribution : public contract {
 
          ACTION populate(name distri_id, vector <dropdata> data, bool allow_modify);
          ACTION empty(name distri_id, uint8_t batch_size);
-         ACTION send(name distri_id, uint8_t batch_size);
+         ACTION send(name distri_id, uint8_t batch_size, uint64_t nonce);
          ACTION claim(name distri_id, name receiver);
 
          [[eosio::on_notify("eosio.token::transfer")]]


### PR DESCRIPTION
this pr  just adds a nonce to the send action to counteract duplicate trx errors when calling the action in a loop. the nonce must be an int.